### PR TITLE
Adding ColorHelpers.HexadecimalToRgb(string hex) + Tests

### DIFF
--- a/src/Skybrud.Colors/ColorHelpers.cs
+++ b/src/Skybrud.Colors/ColorHelpers.cs
@@ -224,6 +224,49 @@ namespace Skybrud.Colors {
         }
 
         /// <summary>
+        /// Converts a <see cref="string"/> Hexadecimal color code to an instance of <see cref="RgbColor"/>.
+        /// </summary>
+        /// <param name="hex">The Hexadecimal color value</param>
+        /// <returns></returns>
+        public static RgbColor HexadecimalToRgb(string hex)
+        {
+            //Based on https://www.programmingalgorithms.com/algorithm/hexadecimal-to-rgb/
+
+            if (hex.StartsWith("#"))
+                hex = hex.Remove(0, 1);
+
+            byte r = (byte)HexadecimalToDecimal(hex.Substring(0, 2));
+            byte g = (byte)HexadecimalToDecimal(hex.Substring(2, 2));
+            byte b = (byte)HexadecimalToDecimal(hex.Substring(4, 2));
+
+            return new RgbColor(r, g, b);
+        }
+
+        private static int HexadecimalToDecimal(string hex)
+        {
+            //From https://www.programmingalgorithms.com/algorithm/hexadecimal-to-rgb/
+
+            hex = hex.ToUpper();
+
+            int hexLength = hex.Length;
+            double dec = 0;
+
+            for (int i = 0; i < hexLength; ++i)
+            {
+                byte b = (byte)hex[i];
+
+                if (b >= 48 && b <= 57)
+                    b -= 48;
+                else if (b >= 65 && b <= 70)
+                    b -= 55;
+
+                dec += b * Math.Pow(16, ((hexLength - i) - 1));
+            }
+
+            return (int)dec;
+        }
+
+        /// <summary>
         /// Calculates the color compoment for when converting a HSL color to a RGB color.
         /// </summary>
         /// <param name="temp1"></param>

--- a/src/Skybrud.Colors/Properties/AssemblyInfo.json
+++ b/src/Skybrud.Colors/Properties/AssemblyInfo.json
@@ -6,5 +6,5 @@
   "copyright": "Copyright © 2018",
   "version": "1.0.2.0",
   "informationalVersion": "1.0.2",
-  "fileVersion": "0.0.855.1"
+  "fileVersion": "0.0.1901.7"
 }

--- a/src/Skybrud.Colors/Properties/AssemblyInfoGenerated.cs
+++ b/src/Skybrud.Colors/Properties/AssemblyInfoGenerated.cs
@@ -1,4 +1,4 @@
 using System.Reflection;
 
-[assembly: AssemblyFileVersion("0.0.855.1")]
+[assembly: AssemblyFileVersion("0.0.1901.7")]
 

--- a/src/UnitTestProject1/RgbColorTests.cs
+++ b/src/UnitTestProject1/RgbColorTests.cs
@@ -23,6 +23,20 @@ namespace UnitTestProject1 {
         }
 
         [TestMethod]
+        public void FromHex()
+        {
+            foreach (HtmlColorSample sample in HtmlColorSamples.All)
+            {
+                string hex = sample.Hex;
+                RgbColor colorTest = ColorHelpers.HexadecimalToRgb(hex);
+                Assert.AreEqual(sample.Hex, colorTest.ToHex(), sample.Name);
+                Assert.AreEqual(sample.Rgb.Red, colorTest.Red, sample.Name);
+                Assert.AreEqual(sample.Rgb.Green, colorTest.Green, sample.Name);
+                Assert.AreEqual(sample.Rgb.Blue, colorTest.Blue, sample.Name);
+            }
+        }
+
+        [TestMethod]
         public void ToHsl() {
 
             foreach (HtmlColorSample sample in HtmlColorSamples.All) {


### PR DESCRIPTION
Added a static function to convert a hex code to an RgbColor, which can then be further manipulated. I used this for the code: https://www.programmingalgorithms.com/algorithm/hexadecimal-to-rgb/ 