### PR TITLE
ColorUtils Consolidation + HexToRgb()

### DIFF
--- a/src/Skybrud.Colors/ColorHelpers.cs
+++ b/src/Skybrud.Colors/ColorHelpers.cs
@@ -224,6 +224,49 @@ namespace Skybrud.Colors {
         }
 
         /// <summary>
+        /// Converts a <see cref="string"/> Hexadecimal color code to an instance of <see cref="RgbColor"/>.
+        /// </summary>
+        /// <param name="hex">The Hexadecimal color value</param>
+        /// <returns></returns>
+        public static RgbColor HexadecimalToRgb(string hex)
+        {
+            //Based on https://www.programmingalgorithms.com/algorithm/hexadecimal-to-rgb/
+
+            if (hex.StartsWith("#"))
+                hex = hex.Remove(0, 1);
+
+            byte r = (byte)HexadecimalToDecimal(hex.Substring(0, 2));
+            byte g = (byte)HexadecimalToDecimal(hex.Substring(2, 2));
+            byte b = (byte)HexadecimalToDecimal(hex.Substring(4, 2));
+
+            return new RgbColor(r, g, b);
+        }
+
+        private static int HexadecimalToDecimal(string hex)
+        {
+            //From https://www.programmingalgorithms.com/algorithm/hexadecimal-to-rgb/
+
+            hex = hex.ToUpper();
+
+            int hexLength = hex.Length;
+            double dec = 0;
+
+            for (int i = 0; i < hexLength; ++i)
+            {
+                byte b = (byte)hex[i];
+
+                if (b >= 48 && b <= 57)
+                    b -= 48;
+                else if (b >= 65 && b <= 70)
+                    b -= 55;
+
+                dec += b * Math.Pow(16, ((hexLength - i) - 1));
+            }
+
+            return (int)dec;
+        }
+
+        /// <summary>
         /// Calculates the color compoment for when converting a HSL color to a RGB color.
         /// </summary>
         /// <param name="temp1"></param>

--- a/src/Skybrud.Colors/ColorHelpers.cs
+++ b/src/Skybrud.Colors/ColorHelpers.cs
@@ -1,14 +1,16 @@
-﻿using System;
-using System.Globalization;
-using System.Text.RegularExpressions;
-
-namespace Skybrud.Colors {
+﻿namespace Skybrud.Colors
+{
+    using System;
+    using System.Globalization;
+    using System.Text.RegularExpressions;
 
     /// <summary>
     /// Static helper methods for various color calculations.
     /// </summary>
-    public static class ColorHelpers {
-
+    [Obsolete("Use 'ColorUtils'")]
+    public static class ColorHelpers
+    {
+        #region Misc
         /// <summary>
         /// Returns the maximum value of <paramref name="a"/>, <paramref name="b"/> and <paramref name="c"/>.
         /// </summary>
@@ -16,7 +18,9 @@ namespace Skybrud.Colors {
         /// <param name="b">The second value.</param>
         /// <param name="c">The third value.</param>
         /// <returns>The maximum value.</returns>
-        public static double Max(double a, double b, double c) {
+        [Obsolete("Use 'ColorUtils.Max()'")]
+        public static double Max(double a, double b, double c)
+        {
             return Math.Max(a, Math.Max(b, c));
         }
 
@@ -27,7 +31,9 @@ namespace Skybrud.Colors {
         /// <param name="b">The second value.</param>
         /// <param name="c">The third value.</param>
         /// <returns>The minimum value.</returns>
-        public static double Min(double a, double b, double c) {
+        [Obsolete("Use 'ColorUtils.Min()'")]
+        public static double Min(double a, double b, double c)
+        {
             return Math.Min(a, Math.Min(b, c));
         }
 
@@ -38,7 +44,9 @@ namespace Skybrud.Colors {
         /// <param name="b">The second value.</param>
         /// <param name="c">The third value.</param>
         /// <returns>The maximum value.</returns>
-        public static float Max(float a, float b, float c) {
+        [Obsolete("Use 'ColorUtils.Max()'")]
+        public static float Max(float a, float b, float c)
+        {
             return Math.Max(a, Math.Max(b, c));
         }
 
@@ -49,8 +57,29 @@ namespace Skybrud.Colors {
         /// <param name="b">The second value.</param>
         /// <param name="c">The third value.</param>
         /// <returns>The minimum value.</returns>
-        public static float Min(float a, float b, float c) {
+        [Obsolete("Use 'ColorUtils.Min()'")]
+        public static float Min(float a, float b, float c)
+        {
             return Math.Min(a, Math.Min(b, c));
+        }
+
+        #endregion
+
+        #region RGB -> HSL
+
+        /// <summary>
+        /// Converts a RGB color to an HSL color.
+        /// </summary>
+        /// <param name="red">The amount of red in the RGB color.</param>
+        /// <param name="green">The amount of green in the RGB color.</param>
+        /// <param name="blue">The amount of blue in the RGB color.</param>
+        /// <param name="hue">The amount of hue in the HSL color.</param>
+        /// <param name="saturation">The amount of saturation in the HSL color.</param>
+        /// <param name="lightness">The amount of lightness in the HSL color.</param>
+        [Obsolete("Use 'ColorUtils()'")]
+        public static void RgbToHslFloat(byte red, byte green, byte blue, out float hue, out float saturation, out float lightness)
+        {
+            ColorUtils.RgbToHslFloat(red, green, blue, out hue, out saturation, out lightness);
         }
 
         /// <summary>
@@ -62,110 +91,15 @@ namespace Skybrud.Colors {
         /// <param name="hue">The amount of hue in the HSL color.</param>
         /// <param name="saturation">The amount of saturation in the HSL color.</param>
         /// <param name="lightness">The amount of lightness in the HSL color.</param>
-        public static void RgbToHslFloat(byte red, byte green, byte blue, out float hue, out float saturation, out float lightness) {
-
-            // Convert to values from 0-1 (linear)
-            float r = red / 255f;
-            float g = green / 255f;
-            float b = blue / 255f;
-
-            // Get the maximum and minimum values
-            float max = Max(r, g, b);
-            float min = Min(r, g, b);
-
-            // Calculate the lightness
-            lightness = (max + min) / 2f;
-
-            // Calculate the saturation
-            saturation = 0;
-            if (Math.Abs(max - min) > Double.Epsilon) {
-                if (lightness < 0.5) {
-                    saturation = (max - min) / (max + min);
-                } else {
-                    saturation = (max - min) / (2.0f - max - min);
-                }
-            }
-
-            // Calculate the hue
-            hue = 0;
-            if (Math.Abs(r - max) < Double.Epsilon) {
-                hue = (g - b) / (max - min);
-            } else if (Math.Abs(g - max) < Double.Epsilon) {
-                hue = 2.0f + (b - r) / (max - min);
-            } else if (Math.Abs(b - max) < Double.Epsilon) {
-                hue = 4.0f + (r - g) / (max - min);
-            }
-
-            // Convert the hue to degrees
-            hue = hue * 60;
-
-            // Make sure hue is a positive number
-            if (hue < 0.0) hue += 360;
-
-            // Convert the hue back to a decimal
-            hue = hue / 360f;
-
-            // Make sure hue is not NaN
-            if (Single.IsNaN(hue)) hue = 0;
-
+        [Obsolete("Use 'ColorUtils()'")]
+        public static void RgbToHsl(byte red, byte green, byte blue, out double hue, out double saturation, out double lightness)
+        {
+            ColorUtils.RgbToHsl(red, green, blue, out hue, out saturation, out lightness);
         }
 
-        /// <summary>
-        /// Converts a RGB color to an HSL color.
-        /// </summary>
-        /// <param name="red">The amount of red in the RGB color.</param>
-        /// <param name="green">The amount of green in the RGB color.</param>
-        /// <param name="blue">The amount of blue in the RGB color.</param>
-        /// <param name="hue">The amount of hue in the HSL color.</param>
-        /// <param name="saturation">The amount of saturation in the HSL color.</param>
-        /// <param name="lightness">The amount of lightness in the HSL color.</param>
-        public static void RgbToHsl(byte red, byte green, byte blue, out double hue, out double saturation, out double lightness) {
+        #endregion
 
-            // Convert to values from 0-1 (linear)
-            double r = red / 255d;
-            double g = green / 255d;
-            double b = blue / 255d;
-
-            // Get the maximum and minimum values
-            double max = Max(r, g, b);
-            double min = Min(r, g, b);
-
-            // Calculate the lightness
-            lightness = (max + min) / 2d;
-
-            // Calculate the saturation
-            saturation = 0;
-            if (Math.Abs(max - min) > Double.Epsilon) {
-                if (lightness < 0.5) {
-                    saturation = (max - min) / (max + min);
-                } else {
-                    saturation = (max - min) / (2.0d - max - min);
-                }
-            }
-
-            // Calculate the hue
-            hue = 0;
-            if (Math.Abs(r - max) < Double.Epsilon) {
-                hue = (g - b) / (max - min);
-            } else if (Math.Abs(g - max) < Double.Epsilon) {
-                hue = 2.0d + (b - r) / (max - min);
-            } else if (Math.Abs(b - max) < Double.Epsilon) {
-                hue = 4.0d + (r - g) / (max - min);
-            }
-
-            // Convert the hue to degrees
-            hue = hue * 60;
-
-            // Make sure hue is a positive number
-            if (hue < 0.0) hue += 360;
-
-            // Convert the hue back to a decimal
-            hue = hue / 360.0;
-
-            // Make sure hue is not NaN
-            if (Double.IsNaN(hue)) hue = 0;
-
-        }
+        #region HSL -> RGB
 
         /// <summary>
         /// Converts an HSL color to a RGB color.
@@ -176,13 +110,11 @@ namespace Skybrud.Colors {
         /// <param name="red">The amount of red in the RGB color.</param>
         /// <param name="green">The amount of green in the RGB color.</param>
         /// <param name="blue">The amount of blue in the RGB color.</param>
-        public static void HslToRgb(double hue, double saturation, double lightness, out int red, out int green, out int blue) {
-            RgbColor color = HslToRgb(new HslColor(hue, saturation, lightness));
-            red = color.Red;
-            green = color.Green;
-            blue = color.Blue;
+        [Obsolete("Use 'ColorUtils.HslToRgb()'")]
+        public static void HslToRgb(double hue, double saturation, double lightness, out int red, out int green, out int blue)
+        {
+             ColorUtils.HslToRgb(new HslColor(hue, saturation, lightness), out red,out green,out blue);
         }
-
 
         /// <summary>
         /// Converts the specified <see cref="HslColor"/> to a RGB color.
@@ -191,150 +123,36 @@ namespace Skybrud.Colors {
         /// <param name="red">The amount of red in the RGB color.</param>
         /// <param name="green">The amount of green in the RGB color.</param>
         /// <param name="blue">The amount of blue in the RGB color.</param>
-        public static void HslToRgb(HslColor hsl, out int red, out int green, out int blue) {
-            HslToRgb(hsl.Hue, hsl.Saturation, hsl.Lightness, out red, out green, out blue);
+        [Obsolete("Use 'ColorUtils.HslToRgb()'")]
+        public static void HslToRgb(HslColor hsl, out int red, out int green, out int blue)
+        {
+            ColorUtils.HslToRgb(hsl, out red, out green, out blue);
         }
-        
+
         /// <summary>
         /// Converts an instance of <see cref="HslColor"/> to an instance of <see cref="RgbColor"/>.
         /// </summary>
         /// <param name="hsl">The <see cref="HslColor"/> to be converted.</param>
         /// <returns>An instance of <see cref="RgbColor"/>.</returns>
-        public static RgbColor HslToRgb(HslColor hsl) {
-
-            // TODO: Needs documentation/references
-
-            double r = 0, g = 0, b = 0;
-            if (Math.Abs(hsl.Lightness) > Double.Epsilon) {
-                if (Math.Abs(hsl.Saturation) < Double.Epsilon) {
-                    r = g = b = hsl.Lightness;
-                } else {
-                    double temp2 = GetTemp2(hsl);
-                    double temp1 = 2.0 * hsl.Lightness - temp2;
-
-                    r = GetColorComponent(temp1, temp2, hsl.Hue + 1.0 / 3.0);
-                    g = GetColorComponent(temp1, temp2, hsl.Hue);
-                    b = GetColorComponent(temp1, temp2, hsl.Hue - 1.0 / 3.0);
-                }
-            }
-            
-            // Convert from 0-1 to 0-255
-            return new RgbColor(255 * r, 255 * g, 255 * b);
-        
-        }
-
-        /// <summary>
-        /// Converts a <see cref="string"/> Hexadecimal color code to an instance of <see cref="RgbColor"/>.
-        /// </summary>
-        /// <param name="hex">The Hexadecimal color value</param>
-        /// <returns></returns>
-        public static RgbColor HexadecimalToRgb(string hex)
+        [Obsolete("Use 'ColorUtils.HslToRgb()'")]
+        public static RgbColor HslToRgb(HslColor hsl)
         {
-            //Based on https://www.programmingalgorithms.com/algorithm/hexadecimal-to-rgb/
-
-            if (hex.StartsWith("#"))
-                hex = hex.Remove(0, 1);
-
-            byte r = (byte)HexadecimalToDecimal(hex.Substring(0, 2));
-            byte g = (byte)HexadecimalToDecimal(hex.Substring(2, 2));
-            byte b = (byte)HexadecimalToDecimal(hex.Substring(4, 2));
-
-            return new RgbColor(r, g, b);
+            return ColorUtils.HslToRgb(hsl);
         }
-
-        private static int HexadecimalToDecimal(string hex)
-        {
-            //From https://www.programmingalgorithms.com/algorithm/hexadecimal-to-rgb/
-
-            hex = hex.ToUpper();
-
-            int hexLength = hex.Length;
-            double dec = 0;
-
-            for (int i = 0; i < hexLength; ++i)
-            {
-                byte b = (byte)hex[i];
-
-                if (b >= 48 && b <= 57)
-                    b -= 48;
-                else if (b >= 65 && b <= 70)
-                    b -= 55;
-
-                dec += b * Math.Pow(16, ((hexLength - i) - 1));
-            }
-
-            return (int)dec;
-        }
-
-        /// <summary>
-        /// Calculates the color compoment for when converting a HSL color to a RGB color.
-        /// </summary>
-        /// <param name="temp1"></param>
-        /// <param name="temp2"></param>
-        /// <param name="temp3"></param>
-        /// <returns>The color component.</returns>
-        private static double GetColorComponent(double temp1, double temp2, double temp3) {
-
-            // TODO: Needs documentation/references
-            
-            temp3 = MoveIntoRange(temp3);
-            if (temp3 < 1.0 / 6.0) return temp1 + (temp2 - temp1) * 6.0 * temp3;
-            if (temp3 < 0.5) return temp2;
-            if (temp3 < 2.0 / 3.0) return temp1 + ((temp2 - temp1) * ((2.0 / 3.0) - temp3) * 6.0);
-            return temp1;
         
-        }
+        #endregion
 
-        /// <summary>
-        /// Method used internally for when converting a HSL color to a RGB color.
-        /// </summary>
-        private static double MoveIntoRange(double temp3) {
-
-            // TODO: Needs documentation/references
-
-            if (temp3 < 0.0) {
-                temp3 += 1.0;
-            } else if (temp3 > 1.0) {
-                temp3 -= 1.0;
-            }
-                
-            return temp3;
-        
-        }
-
-        /// <summary>
-        /// Method used internally for when converting a HSL color to a RGB color.
-        /// </summary>
-        private static double GetTemp2(HslColor hslColor) {
-
-            // TODO: Needs documentation/references
-            
-            double temp2;
-
-            if (hslColor.Lightness < 0.5) {
-                temp2 = hslColor.Lightness * (1.0 + hslColor.Saturation);
-            } else  {
-                temp2 = hslColor.Lightness + hslColor.Saturation - (hslColor.Lightness * hslColor.Saturation);
-            }
-            
-            return temp2;
-        
-        }
+        #region Parsing Moved to ColorUtils
 
         /// <summary>
         /// Parses the specified <paramref name="str"/> into an instance of <see cref="IColor"/>.
         /// </summary>
         /// <param name="str">The input string to be parsed.</param>
         /// <returns>An instance of <see cref="IColor"/>.</returns>
-        public static IColor Parse(string str) {
-
-            if (String.IsNullOrWhiteSpace(str)) throw new ArgumentNullException("str");
-
-            IColor color;
-            if (TryParse(str, out color)) return color;
-
-            throw new FormatException("Input string was not in a correct format.");
-
+        [Obsolete("Use 'ColorUtils.Parse()'")]
+        public static IColor Parse(string str)
+        {
+            return ColorUtils.Parse(str);
         }
 
         /// <summary>
@@ -343,50 +161,13 @@ namespace Skybrud.Colors {
         /// <param name="str">The input string to be parsed.</param>
         /// <param name="color">An instance of <see cref="IColor"/>.</param>
         /// <returns><c>true</c> if <paramref name="str"/> was converted successfully; otherwise, <c>false</c>.</returns>
-        public static bool TryParse(string str, out IColor color) {
-
-            color = null;
-
-            // Return "false" if the string is empty
-            if (String.IsNullOrWhiteSpace(str)) return false;
-
-            // Strip a leading hashtag and convert to lowercase
-            str = str.TrimStart('#').ToLower();
-
-            // Time for some regex :D
-            Match m1 = Regex.Match(str, "^([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$");
-            Match m2 = Regex.Match(str, "^([0-9a-f]{1})([0-9a-f]{1})([0-9a-f]{1})$");
-
-            Match m3 = Regex.Match(str, "^hsl\\(([0-9]+), ([0-9]+)%, ([0-9]+)%\\)$");
-            
-            if (m1.Success) {
-                Byte.TryParse(m1.Groups[1].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte r);
-                Byte.TryParse(m1.Groups[2].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte g);
-                Byte.TryParse(m1.Groups[3].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte b);
-                color = new RgbColor(r, g, b);
-                return true;
-            }
-
-            if (m2.Success) {
-                Byte.TryParse(m2.Groups[1].Value + m2.Groups[1].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte r);
-                Byte.TryParse(m2.Groups[2].Value + m2.Groups[2].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte g);
-                Byte.TryParse(m2.Groups[3].Value + m2.Groups[3].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte b);
-                color = new RgbColor(r, g, b);
-                return true;
-            }
-
-            if (m3.Success) {
-                float h = Int32.Parse(m3.Groups[1].Value) / 360f;
-                float s = Int32.Parse(m3.Groups[2].Value) / 100f;
-                float l = Int32.Parse(m3.Groups[3].Value) / 100f;
-                color = new HslColor(h, s, l);
-                return true;
-            }
-
-            return false;
-
+        [Obsolete("Use 'ColorUtils.TryParse()'")]
+        public static bool TryParse(string str, out IColor color)
+        {
+            return ColorUtils.TryParse(str, out color);
         }
 
+        #endregion
     }
 
 }

--- a/src/Skybrud.Colors/ColorUtils.cs
+++ b/src/Skybrud.Colors/ColorUtils.cs
@@ -1,11 +1,14 @@
-﻿using System;
-
-namespace Skybrud.Colors {
+﻿namespace Skybrud.Colors
+{
+    using System;
+    using System.Globalization;
+    using System.Text.RegularExpressions;
 
     /// <summary>
     /// Utility class with static methods for various color calculations.
     /// </summary>
-    public static class ColorUtils {
+    public static class ColorUtils
+    {
 
         #region Misc
 
@@ -16,7 +19,8 @@ namespace Skybrud.Colors {
         /// <param name="b">The second value.</param>
         /// <param name="c">The third value.</param>
         /// <returns>The maximum value.</returns>
-        public static double Max(double a, double b, double c) {
+        public static double Max(double a, double b, double c)
+        {
             return Math.Max(a, Math.Max(b, c));
         }
 
@@ -27,7 +31,8 @@ namespace Skybrud.Colors {
         /// <param name="b">The second value.</param>
         /// <param name="c">The third value.</param>
         /// <returns>The minimum value.</returns>
-        public static double Min(double a, double b, double c) {
+        public static double Min(double a, double b, double c)
+        {
             return Math.Min(a, Math.Min(b, c));
         }
 
@@ -38,7 +43,8 @@ namespace Skybrud.Colors {
         /// <param name="b">The second value.</param>
         /// <param name="c">The third value.</param>
         /// <returns>The maximum value.</returns>
-        public static float Max(float a, float b, float c) {
+        public static float Max(float a, float b, float c)
+        {
             return Math.Max(a, Math.Max(b, c));
         }
 
@@ -49,7 +55,8 @@ namespace Skybrud.Colors {
         /// <param name="b">The second value.</param>
         /// <param name="c">The third value.</param>
         /// <returns>The minimum value.</returns>
-        public static float Min(float a, float b, float c) {
+        public static float Min(float a, float b, float c)
+        {
             return Math.Min(a, Math.Min(b, c));
         }
 
@@ -60,52 +67,61 @@ namespace Skybrud.Colors {
         /// <param name="temp2"></param>
         /// <param name="temp3"></param>
         /// <returns>The color component.</returns>
-        private static double GetColorComponent(double temp1, double temp2, double temp3) {
+        private static double GetColorComponent(double temp1, double temp2, double temp3)
+        {
 
             // TODO: Needs documentation/references
-            
+
             temp3 = MoveIntoRange(temp3);
             if (temp3 < 1.0 / 6.0) return temp1 + (temp2 - temp1) * 6.0 * temp3;
             if (temp3 < 0.5) return temp2;
             if (temp3 < 2.0 / 3.0) return temp1 + ((temp2 - temp1) * ((2.0 / 3.0) - temp3) * 6.0);
             return temp1;
-        
+
         }
 
         /// <summary>
         /// Method used internally for when converting a HSL color to a RGB color.
         /// </summary>
-        private static double MoveIntoRange(double temp3) {
+        private static double MoveIntoRange(double temp3)
+        {
 
             // TODO: Needs documentation/references
 
-            if (temp3 < 0.0) {
+            if (temp3 < 0.0)
+            {
                 temp3 += 1.0;
-            } else if (temp3 > 1.0) {
+            }
+            else if (temp3 > 1.0)
+            {
                 temp3 -= 1.0;
             }
-                
+
             return temp3;
-        
+
         }
 
         /// <summary>
         /// Method used internally for when converting a HSL color to a RGB color.
         /// </summary>
-        private static double GetTemp2(double saturation, double lightness) {
+        private static double GetTemp2(double saturation, double lightness)
+        {
 
             // TODO: Needs documentation/references
-            
+
             double temp2;
 
-            if (lightness < 0.5) {
+            if (lightness < 0.5)
+            {
                 temp2 = lightness * (1.0 + saturation);
-            } else  {
+            }
+            else
+            {
                 temp2 = lightness + saturation - (lightness * saturation);
             }
-            
+
             return temp2;
-        
+
         }
 
         #endregion
@@ -122,24 +138,28 @@ namespace Skybrud.Colors {
         /// <param name="m">The magenta in the CMYM color.</param>
         /// <param name="y">The yellow in the CMYM color.</param>
         /// <param name="k">The key in the CMYM color.</param>
-        public static void CmyToCmyk(double cyan, double magenta, double yellow, out double c, out double m, out double y, out double k) {
+        public static void CmyToCmyk(double cyan, double magenta, double yellow, out double c, out double m, out double y, out double k)
+        {
 
             double key = 1;
 
             if (cyan < key) key = cyan;
             if (magenta < key) key = magenta;
             if (yellow < key) key = yellow;
-            
-            if (Math.Abs(key - 1d) < Double.Epsilon) {
+
+            if (Math.Abs(key - 1d) < Double.Epsilon)
+            {
                 c = 0;
                 m = 0;
                 y = 0;
-            } else {
+            }
+            else
+            {
                 c = (cyan - key) / (1d - key);
                 m = (magenta - key) / (1d - key);
                 y = (yellow - key) / (1d - key);
             }
-            
+
             k = key;
 
         }
@@ -151,7 +171,8 @@ namespace Skybrud.Colors {
         /// <param name="magenta">The magenta in the CMY color.</param>
         /// <param name="yellow">The yellow in the CMY color.</param>
         /// <returns>An instance of <see cref="CmykColor"/> representing the CMYK color.</returns>
-        public static CmykColor CmyToCmyk(double cyan, double magenta, double yellow) {
+        public static CmykColor CmyToCmyk(double cyan, double magenta, double yellow)
+        {
             CmyToCmyk(cyan, magenta, yellow, out double c, out double m, out double y, out double k);
             return new CmykColor(c, m, y, k);
         }
@@ -161,7 +182,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="cmy">The CMY color.</param>
         /// <returns>An instance of <see cref="CmykColor"/> representing the CMYK color.</returns>
-        public static CmykColor CmyToCmyk(CmyColor cmy) {
+        public static CmykColor CmyToCmyk(CmyColor cmy)
+        {
             CmyToCmyk(cmy.Cyan, cmy.Magenta, cmy.Yellow, out double c, out double m, out double y, out double k);
             return new CmykColor(c, m, y, k);
         }
@@ -170,20 +192,23 @@ namespace Skybrud.Colors {
 
         #region CMY -> RGB
 
-        public static void CmyToRgb(double cyan, double magenta, double yellow, out byte r, out byte g, out byte b) {
+        public static void CmyToRgb(double cyan, double magenta, double yellow, out byte r, out byte g, out byte b)
+        {
             r = Convert.ToByte((1 - cyan) * 255d);
             g = Convert.ToByte((1 - magenta) * 255d);
             b = Convert.ToByte((1 - yellow) * 255d);
         }
 
-        public static RgbColor CmyToRgb(double cyan, double magenta, double yellow) {
+        public static RgbColor CmyToRgb(double cyan, double magenta, double yellow)
+        {
             byte r = Convert.ToByte((1 - cyan) * 255d);
             byte g = Convert.ToByte((1 - magenta) * 255d);
             byte b = Convert.ToByte((1 - yellow) * 255d);
             return new RgbColor(r, g, b);
         }
 
-        public static RgbColor CmyToRgb(CmyColor cmy) {
+        public static RgbColor CmyToRgb(CmyColor cmy)
+        {
             return CmyToRgb(cmy.Cyan, cmy.Magenta, cmy.Yellow);
         }
 
@@ -201,7 +226,8 @@ namespace Skybrud.Colors {
         /// <param name="c">The cyan in the CMY color.</param>
         /// <param name="m">The magenta in the CMY color.</param>
         /// <param name="y">The yellow in the CMY color.</param>
-        public static void CmykToCmy(double cyan, double magenta, double yellow, double key, out double c, out double m, out double y) {
+        public static void CmykToCmy(double cyan, double magenta, double yellow, double key, out double c, out double m, out double y)
+        {
             c = cyan * (1 - key) + key;
             m = magenta * (1 - key) + key;
             y = yellow * (1 - key) + key;
@@ -215,7 +241,8 @@ namespace Skybrud.Colors {
         /// <param name="yellow">The yellow in the CMYK color.</param>
         /// <param name="key">The key in the CMYK color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the CMY color.</returns>
-        public static CmyColor CmykToCmy(double cyan, double magenta, double yellow, double key) {
+        public static CmyColor CmykToCmy(double cyan, double magenta, double yellow, double key)
+        {
             CmykToCmy(cyan, magenta, yellow, key, out double c, out double m, out double y);
             return new CmyColor(c, m, y);
         }
@@ -225,7 +252,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="cmyk">The CMYK color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the CMY color.</returns>
-        public static CmyColor CmykToCmy(CmykColor cmyk) {
+        public static CmyColor CmykToCmy(CmykColor cmyk)
+        {
             CmykToCmy(cmyk.Cyan, cmyk.Magenta, cmyk.Yellow, cmyk.Key, out double c, out double m, out double y);
             return new CmyColor(c, m, y);
         }
@@ -234,18 +262,21 @@ namespace Skybrud.Colors {
 
         #region CMYK -> RGB
 
-        public static void CmykToRgb(double cyan, double magenta, double yellow, double key, out byte r, out byte g, out byte b) {
+        public static void CmykToRgb(double cyan, double magenta, double yellow, double key, out byte r, out byte g, out byte b)
+        {
             CmykToCmy(cyan, magenta, yellow, key, out double c, out double m, out double y);
             CmyToRgb(c, m, y, out r, out g, out b);
         }
 
-        public static RgbColor CmykToRgb(double cyan, double magenta, double yellow, double key) {
+        public static RgbColor CmykToRgb(double cyan, double magenta, double yellow, double key)
+        {
             CmykToCmy(cyan, magenta, yellow, key, out double c, out double m, out double y);
             CmyToRgb(c, m, y, out byte r, out byte g, out byte b);
             return new RgbColor(r, g, b);
         }
 
-        public static RgbColor CmykToRgb(CmykColor cmyk) {
+        public static RgbColor CmykToRgb(CmykColor cmyk)
+        {
             return CmykToRgb(cmyk.Cyan, cmyk.Magenta, cmyk.Yellow, cmyk.Key);
         }
 
@@ -262,7 +293,8 @@ namespace Skybrud.Colors {
         /// <param name="c">The cyan of the CMY color.</param>
         /// <param name="m">The magenta of the CMY color.</param>
         /// <param name="y">The yellow of the CMY color.</param>
-        public static void HslToCmy(double hue, double saturation, double lightness, out double c, out double m, out double y) {
+        public static void HslToCmy(double hue, double saturation, double lightness, out double c, out double m, out double y)
+        {
             HslToRgb(hue, saturation, lightness, out int r, out int g, out int b);
             RgbToCmy(r, g, b, out c, out m, out y);
         }
@@ -274,7 +306,8 @@ namespace Skybrud.Colors {
         /// <param name="saturation">The saturation of the HSL color.</param>
         /// <param name="lightness">The lightness of the HSL color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the HSL color.</returns>
-        public static CmyColor HslToCmy(double hue, double saturation, double lightness) {
+        public static CmyColor HslToCmy(double hue, double saturation, double lightness)
+        {
             HslToRgb(hue, saturation, lightness, out int r, out int g, out int b);
             RgbToCmy(r, g, b, out double c, out double m, out double y);
             return new CmyColor(c, m, y);
@@ -285,7 +318,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="hsl">The HSL color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the HSL color.</returns>
-        public static CmyColor HslToCmy(HslColor hsl) {
+        public static CmyColor HslToCmy(HslColor hsl)
+        {
             HslToRgb(hsl.Hue, hsl.Saturation, hsl.Lightness, out int r, out int g, out int b);
             RgbToCmy(r, g, b, out double c, out double m, out double y);
             return new CmyColor(c, m, y);
@@ -305,7 +339,8 @@ namespace Skybrud.Colors {
         /// <param name="m">The magenta of the CMY color.</param>
         /// <param name="y">The yellow of the CMY color.</param>
         /// <param name="k">The key of the CMY color.</param>
-        public static void HslToCmyk(double hue, double saturation, double lightness, out double c, out double m, out double y, out double k) {
+        public static void HslToCmyk(double hue, double saturation, double lightness, out double c, out double m, out double y, out double k)
+        {
             HslToRgb(hue, saturation, lightness, out int r, out int g, out int b);
             RgbToCmyk(r, g, b, out c, out m, out y, out k);
         }
@@ -317,7 +352,8 @@ namespace Skybrud.Colors {
         /// <param name="saturation">The saturation of the HSL color.</param>
         /// <param name="lightness">The lightness of the HSL color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the HSL color.</returns>
-        public static CmykColor HslToCmyk(double hue, double saturation, double lightness) {
+        public static CmykColor HslToCmyk(double hue, double saturation, double lightness)
+        {
             HslToRgb(hue, saturation, lightness, out int r, out int g, out int b);
             RgbToCmyk(r, g, b, out double c, out double m, out double y, out double k);
             return new CmykColor(c, m, y, k);
@@ -328,7 +364,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="hsl">The HSL color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the HSL color.</returns>
-        public static CmykColor HslToCmyk(HslColor hsl) {
+        public static CmykColor HslToCmyk(HslColor hsl)
+        {
             HslToRgb(hsl.Hue, hsl.Saturation, hsl.Lightness, out int r, out int g, out int b);
             RgbToCmyk(r, g, b, out double c, out double m, out double y, out double k);
             return new CmykColor(c, m, y, k);
@@ -347,7 +384,8 @@ namespace Skybrud.Colors {
         /// <param name="h">The hue of the HSV color.</param>
         /// <param name="s">The saturation of the HSV color.</param>
         /// <param name="v">The value of the HSV color.</param>
-        public static void HslToHsv(double hue, double saturation, double lightness, out double h, out double s, out double v) {
+        public static void HslToHsv(double hue, double saturation, double lightness, out double h, out double s, out double v)
+        {
 
             // TODO: Needs documentation/references
 
@@ -368,7 +406,8 @@ namespace Skybrud.Colors {
         /// <param name="saturation">The saturation of the HSL color.</param>
         /// <param name="lightness">The lightness of the HSL color.</param>
         /// <returns>An instance of <see cref="HsvColor"/> representing the HSV color.</returns>
-        public static HsvColor HslToHsv(double hue, double saturation, double lightness) {
+        public static HsvColor HslToHsv(double hue, double saturation, double lightness)
+        {
             HslToHsv(hue, saturation, lightness, out double h, out double s, out double v);
             return new HsvColor(h, s, v);
         }
@@ -378,7 +417,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="hsl">The HSL color.</param>
         /// <returns>An instance of <see cref="HsvColor"/> representing the HSV color.</returns>
-        public static HsvColor HslToHsv(HslColor hsl) {
+        public static HsvColor HslToHsv(HslColor hsl)
+        {
             HslToHsv(hsl.Hue, hsl.Saturation, hsl.Lightness, out double h, out double s, out double v);
             return new HsvColor(h, s, v);
         }
@@ -396,15 +436,20 @@ namespace Skybrud.Colors {
         /// <param name="red">The amount of red in the RGB color.</param>
         /// <param name="green">The amount of green in the RGB color.</param>
         /// <param name="blue">The amount of blue in the RGB color.</param>
-        public static void HslToRgb(double hue, double saturation, double lightness, out int red, out int green, out int blue) {
+        public static void HslToRgb(double hue, double saturation, double lightness, out int red, out int green, out int blue)
+        {
 
             // TODO: Needs documentation/references
 
             double r = 0, g = 0, b = 0;
-            if (Math.Abs(lightness) > Double.Epsilon) {
-                if (Math.Abs(saturation) < Double.Epsilon) {
+            if (Math.Abs(lightness) > Double.Epsilon)
+            {
+                if (Math.Abs(saturation) < Double.Epsilon)
+                {
                     r = g = b = lightness;
-                } else {
+                }
+                else
+                {
                     double temp2 = GetTemp2(saturation, lightness);
                     double temp1 = 2.0 * lightness - temp2;
                     r = GetColorComponent(temp1, temp2, hue + 1.0 / 3.0);
@@ -414,9 +459,9 @@ namespace Skybrud.Colors {
             }
 
             // Convert from 0-1 to 0-255
-            red = (int) Math.Round(r * 255);
-            green = (int) Math.Round(g * 255);
-            blue = (int) Math.Round(b * 255);
+            red = (int)Math.Round(r * 255);
+            green = (int)Math.Round(g * 255);
+            blue = (int)Math.Round(b * 255);
 
         }
 
@@ -427,7 +472,8 @@ namespace Skybrud.Colors {
         /// <param name="saturation">The amount of saturation in the HSL color.</param>
         /// <param name="lightness">The amount of lightness in the HSL color.</param>
         /// <returns>An instance of <see cref="RgbColor"/> representing the RGB color.</returns>
-        public static RgbColor HslToRgb(double hue, double saturation, double lightness) {
+        public static RgbColor HslToRgb(double hue, double saturation, double lightness)
+        {
             HslToRgb(hue, saturation, lightness, out int red, out int green, out int blue);
             return new RgbColor(red, green, blue);
         }
@@ -439,16 +485,18 @@ namespace Skybrud.Colors {
         /// <param name="red">The amount of red in the RGB color.</param>
         /// <param name="green">The amount of green in the RGB color.</param>
         /// <param name="blue">The amount of blue in the RGB color.</param>
-        public static void HslToRgb(HslColor hsl, out int red, out int green, out int blue) {
+        public static void HslToRgb(HslColor hsl, out int red, out int green, out int blue)
+        {
             HslToRgb(hsl.Hue, hsl.Saturation, hsl.Lightness, out red, out green, out blue);
         }
-        
+
         /// <summary>
         /// Converts an instance of <see cref="HslColor"/> to an instance of <see cref="RgbColor"/>.
         /// </summary>
         /// <param name="hsl">The <see cref="HslColor"/> to be converted.</param>
         /// <returns>An instance of <see cref="RgbColor"/>.</returns>
-        public static RgbColor HslToRgb(HslColor hsl) {
+        public static RgbColor HslToRgb(HslColor hsl)
+        {
             return HslToRgb(hsl.Hue, hsl.Saturation, hsl.Lightness);
         }
 
@@ -466,7 +514,8 @@ namespace Skybrud.Colors {
         /// <param name="green">The amount of green in the RGBA color.</param>
         /// <param name="blue">The amount of blue in the RGBA color.</param>
         /// <param name="alpha">The amount of opacity in the RGBA color.</param>
-        public static void HslToRgba(double hue, double saturation, double lightness, out int red, out int green, out int blue, out float alpha) {
+        public static void HslToRgba(double hue, double saturation, double lightness, out int red, out int green, out int blue, out float alpha)
+        {
             HslToRgb(hue, saturation, lightness, out red, out green, out blue);
             alpha = 1;
         }
@@ -478,7 +527,8 @@ namespace Skybrud.Colors {
         /// <param name="saturation">The amount of saturation in the HSL color.</param>
         /// <param name="lightness">The amount of lightness in the HSL color.</param>
         /// <returns>An instance of <see cref="RgbaColor"/> representing the RGBA color.</returns>
-        public static RgbaColor HslToRgba(double hue, double saturation, double lightness) {
+        public static RgbaColor HslToRgba(double hue, double saturation, double lightness)
+        {
             HslToRgba(hue, saturation, lightness, out int red, out int green, out int blue, out float alpha);
             return new RgbaColor(red, green, blue, alpha);
         }
@@ -491,7 +541,8 @@ namespace Skybrud.Colors {
         /// <param name="green">The amount of green in the RGB color.</param>
         /// <param name="blue">The amount of blue in the RGB color.</param>
         /// <param name="alpha">The amount of opacity in the RGBA color.</param>
-        public static void HslToRgba(HslColor hsl, out int red, out int green, out int blue, out float alpha) {
+        public static void HslToRgba(HslColor hsl, out int red, out int green, out int blue, out float alpha)
+        {
             HslToRgba(hsl.Hue, hsl.Saturation, hsl.Lightness, out red, out green, out blue, out alpha);
         }
 
@@ -500,7 +551,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="hsl">The <see cref="HslColor"/> to be converted.</param>
         /// <returns>An instance of <see cref="RgbaColor"/>.</returns>
-        public static RgbaColor HslToRgba(HslColor hsl) {
+        public static RgbaColor HslToRgba(HslColor hsl)
+        {
             return HslToRgba(hsl.Hue, hsl.Saturation, hsl.Lightness);
         }
 
@@ -517,7 +569,8 @@ namespace Skybrud.Colors {
         /// <param name="c">The cyan of the CMY color.</param>
         /// <param name="m">The magenta of the CMY color.</param>
         /// <param name="y">The yellow of the CMY color.</param>
-        public static void HsvToCmy(double hue, double saturation, double value, out double c, out double m, out double y) {
+        public static void HsvToCmy(double hue, double saturation, double value, out double c, out double m, out double y)
+        {
             HsvToRgb(hue, saturation, value, out int r, out int g, out int b);
             RgbToCmy(r, g, b, out c, out m, out y);
         }
@@ -529,7 +582,8 @@ namespace Skybrud.Colors {
         /// <param name="saturation">The saturation of the HSV color.</param>
         /// <param name="value">The value of the HSV color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the HSL color.</returns>
-        public static CmyColor HsvToCmy(double hue, double saturation, double value) {
+        public static CmyColor HsvToCmy(double hue, double saturation, double value)
+        {
             HsvToRgb(hue, saturation, value, out int r, out int g, out int b);
             RgbToCmy(r, g, b, out double c, out double m, out double y);
             return new CmyColor(c, m, y);
@@ -540,7 +594,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="hsv">The HSV color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the HSL color.</returns>
-        public static CmyColor HsvToCmy(HsvColor hsv) {
+        public static CmyColor HsvToCmy(HsvColor hsv)
+        {
             HsvToRgb(hsv.Hue, hsv.Saturation, hsv.Value, out int r, out int g, out int b);
             RgbToCmy(r, g, b, out double c, out double m, out double y);
             return new CmyColor(c, m, y);
@@ -560,7 +615,8 @@ namespace Skybrud.Colors {
         /// <param name="m">The magenta of the CMY color.</param>
         /// <param name="y">The yellow of the CMY color.</param>
         /// <param name="k">The key of the CMY color.</param>
-        public static void HsvToCmyk(double hue, double saturation, double value, out double c, out double m, out double y, out double k) {
+        public static void HsvToCmyk(double hue, double saturation, double value, out double c, out double m, out double y, out double k)
+        {
             HsvToRgb(hue, saturation, value, out int r, out int g, out int b);
             RgbToCmyk(r, g, b, out c, out m, out y, out k);
         }
@@ -572,7 +628,8 @@ namespace Skybrud.Colors {
         /// <param name="saturation">The saturation of the HSV color.</param>
         /// <param name="value">The value of the HSV color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the HSL color.</returns>
-        public static CmykColor HsvToCmyk(double hue, double saturation, double value) {
+        public static CmykColor HsvToCmyk(double hue, double saturation, double value)
+        {
             HsvToRgb(hue, saturation, value, out int r, out int g, out int b);
             RgbToCmyk(r, g, b, out double c, out double m, out double y, out double k);
             return new CmykColor(c, m, y, k);
@@ -583,7 +640,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="hsv">The HSV color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the HSL color.</returns>
-        public static CmykColor HsvToCmyk(HsvColor hsv) {
+        public static CmykColor HsvToCmyk(HsvColor hsv)
+        {
             HsvToRgb(hsv.Hue, hsv.Saturation, hsv.Value, out int r, out int g, out int b);
             RgbToCmyk(r, g, b, out double c, out double m, out double y, out double k);
             return new CmykColor(c, m, y, k);
@@ -602,7 +660,8 @@ namespace Skybrud.Colors {
         /// <param name="h">The hue of the HSL color.</param>
         /// <param name="s">The saturation of the HSL color.</param>
         /// <param name="l">The lightness of the HSL color.</param>
-        public static void HsvToHsl(double hue, double saturation, double value, out double h, out double s, out double l) {
+        public static void HsvToHsl(double hue, double saturation, double value, out double h, out double s, out double l)
+        {
 
             // TODO: Needs documentation/references
 
@@ -611,7 +670,8 @@ namespace Skybrud.Colors {
             s = saturation * value;
             s = s / ((l <= 1) ? (l) : 2d - (l));
 
-            if (Double.IsNaN(s)) {
+            if (Double.IsNaN(s))
+            {
                 s = 0;
             }
 
@@ -626,7 +686,8 @@ namespace Skybrud.Colors {
         /// <param name="saturation">The saturation of the HSV color.</param>
         /// <param name="value">The value of the HSV color.</param>
         /// <returns>An instance of <see cref="HslColor"/> representing the HSL color.</returns>
-        public static HslColor HsvToHsl(double hue, double saturation, double value) {
+        public static HslColor HsvToHsl(double hue, double saturation, double value)
+        {
             HsvToHsl(hue, saturation, value, out double h, out double s, out double l);
             return new HslColor(h, s, l);
         }
@@ -636,7 +697,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="hsv">The HSV color.</param>
         /// <returns>An instance of <see cref="HslColor"/> representing the HSL color.</returns>
-        public static HslColor HsvToHsl(HsvColor hsv) {
+        public static HslColor HsvToHsl(HsvColor hsv)
+        {
             HsvToHsl(hsv.Hue, hsv.Saturation, hsv.Value, out double h, out double s, out double l);
             return new HslColor(h, s, l);
         }
@@ -654,7 +716,8 @@ namespace Skybrud.Colors {
         /// <param name="red">The red of the RGB color.</param>
         /// <param name="green">The green of the RGB color.</param>
         /// <param name="blue">The blue of the RGB color.</param>
-        public static void HsvToRgb(double hue, double saturation, double value, out double red, out double green, out double blue) {
+        public static void HsvToRgb(double hue, double saturation, double value, out double red, out double green, out double blue)
+        {
 
             // Convert from HSV to HSL
             HsvToHsl(hue, saturation, value, out double hh, out double ss, out double ll);
@@ -664,7 +727,7 @@ namespace Skybrud.Colors {
             // TODO: Calculate to "double" instead of "int"
 
             red = r;
-            green= g;
+            green = g;
             blue = b;
 
         }
@@ -678,7 +741,8 @@ namespace Skybrud.Colors {
         /// <param name="red">The red of the RGB color.</param>
         /// <param name="green">The green of the RGB color.</param>
         /// <param name="blue">The blue of the RGB color.</param>
-        public static void HsvToRgb(double hue, double saturation, double value, out int red, out int green, out int blue) {
+        public static void HsvToRgb(double hue, double saturation, double value, out int red, out int green, out int blue)
+        {
 
             // Convert from HSV to HSL
             HsvToHsl(hue, saturation, value, out double hh, out double ss, out double ll);
@@ -695,7 +759,8 @@ namespace Skybrud.Colors {
         /// <param name="saturation">The saturation of the HSV color.</param>
         /// <param name="value">The value of the HSV color.</param>
         /// <returns>An instance of <see cref="RgbColor"/> representing the RGB.</returns>
-        public static RgbColor HsvToRgb(double hue, double saturation, double value) {
+        public static RgbColor HsvToRgb(double hue, double saturation, double value)
+        {
             HsvToRgb(hue, saturation, value, out double red, out double green, out double blue);
             return new RgbColor(red, green, blue);
         }
@@ -705,7 +770,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="hsv">The HSV color.</param>
         /// <returns>An instance of <see cref="RgbColor"/> representing the RGB color.</returns>
-        public static RgbColor HsvToRgb(HsvColor hsv) {
+        public static RgbColor HsvToRgb(HsvColor hsv)
+        {
             return HsvToRgb(hsv.Hue, hsv.Saturation, hsv.Value);
         }
 
@@ -723,7 +789,8 @@ namespace Skybrud.Colors {
         /// <param name="green">The green of the RGBA color.</param>
         /// <param name="blue">The blue of the RGBA color.</param>
         /// <param name="alpha">The amount of opacity in the RGBA color.</param>
-        public static void HsvToRgba(double hue, double saturation, double value, out double red, out double green, out double blue, out float alpha) {
+        public static void HsvToRgba(double hue, double saturation, double value, out double red, out double green, out double blue, out float alpha)
+        {
 
             // Convert from HSV to HSL
             HsvToHsl(hue, saturation, value, out double hh, out double ss, out double ll);
@@ -733,7 +800,7 @@ namespace Skybrud.Colors {
             // TODO: Calculate to "double" instead of "int"
 
             red = r;
-            green= g;
+            green = g;
             blue = b;
 
         }
@@ -748,7 +815,8 @@ namespace Skybrud.Colors {
         /// <param name="green">The green of the RGBA color.</param>
         /// <param name="blue">The blue of the RGBA color.</param>
         /// <param name="alpha">The amount of opacity in the RGBA color.</param>
-        public static void HsvToRgba(double hue, double saturation, double value, out int red, out int green, out int blue, out float alpha) {
+        public static void HsvToRgba(double hue, double saturation, double value, out int red, out int green, out int blue, out float alpha)
+        {
 
             // Convert from HSV to HSL
             HsvToHsl(hue, saturation, value, out double hh, out double ss, out double ll);
@@ -765,7 +833,8 @@ namespace Skybrud.Colors {
         /// <param name="saturation">The saturation of the HSV color.</param>
         /// <param name="value">The value of the HSV color.</param>
         /// <returns>An instance of <see cref="RgbaColor"/> representing the RGBA color.</returns>
-        public static RgbaColor HsvToRgba(double hue, double saturation, double value) {
+        public static RgbaColor HsvToRgba(double hue, double saturation, double value)
+        {
             HsvToRgba(hue, saturation, value, out double red, out double green, out double blue, out float aplha);
             return new RgbaColor(red, green, blue, aplha);
         }
@@ -775,7 +844,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="hsv">The HSV color.</param>
         /// <returns>An instance of <see cref="RgbaColor"/> representing the RGB color.</returns>
-        public static RgbaColor HsvToRgba(HsvColor hsv) {
+        public static RgbaColor HsvToRgba(HsvColor hsv)
+        {
             return HsvToRgba(hsv.Hue, hsv.Saturation, hsv.Value);
         }
 
@@ -783,7 +853,7 @@ namespace Skybrud.Colors {
 
         #region RGB -> CMY
 
-                /// <summary>
+        /// <summary>
         /// Converts a <strong>RGB</strong> color to the corresponding <strong>CMY</strong> color.
         /// </summary>
         /// <param name="red">The red of the RGB color.</param>
@@ -792,7 +862,8 @@ namespace Skybrud.Colors {
         /// <param name="c">The cyan of the CMY color.</param>
         /// <param name="m">The magenta of the CMY color.</param>
         /// <param name="y">The yellow of the CMY color.</param>
-        public static void RgbToCmy(int red, int green, int blue, out double c, out double m, out double y) {
+        public static void RgbToCmy(int red, int green, int blue, out double c, out double m, out double y)
+        {
             c = 1 - (red / 255d);
             m = 1 - (green / 255d);
             y = 1 - (blue / 255d);
@@ -807,7 +878,8 @@ namespace Skybrud.Colors {
         /// <param name="c">The cyan of the CMY color.</param>
         /// <param name="m">The magenta of the CMY color.</param>
         /// <param name="y">The yellow of the CMY color.</param>
-        public static void RgbToCmy(double red, double green, double blue, out double c, out double m, out double y) {
+        public static void RgbToCmy(double red, double green, double blue, out double c, out double m, out double y)
+        {
             c = 1 - (red / 255d);
             m = 1 - (green / 255d);
             y = 1 - (blue / 255d);
@@ -820,7 +892,8 @@ namespace Skybrud.Colors {
         /// <param name="green">The green in the RGB color.</param>
         /// <param name="blue">The blue in the RGB color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the CMY color.</returns>
-        public static CmyColor RgbToCmy(double red, double green, double blue) {
+        public static CmyColor RgbToCmy(double red, double green, double blue)
+        {
             double c = 1 - (red / 255d);
             double m = 1 - (green / 255d);
             double y = 1 - (blue / 255d);
@@ -834,7 +907,8 @@ namespace Skybrud.Colors {
         /// <param name="c">The cyan of the CMY color.</param>
         /// <param name="m">The magenta of the CMY color.</param>
         /// <param name="y">The yellow of the CMY color.</param>
-        public static void RgbToCmy(RgbColor rgb, out double c, out double m, out double y) {
+        public static void RgbToCmy(RgbColor rgb, out double c, out double m, out double y)
+        {
             RgbToCmy(rgb.Red, rgb.Green, rgb.Blue, out c, out m, out y);
         }
 
@@ -843,7 +917,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="rgb">The RGB color.</param>
         /// <returns>An instance of <see cref="CmyColor"/> representing the CMY color.</returns>
-        public static CmyColor RgbToCmy(RgbColor rgb) {
+        public static CmyColor RgbToCmy(RgbColor rgb)
+        {
             return RgbToCmy(rgb.Red, rgb.Green, rgb.Blue);
         }
 
@@ -861,7 +936,8 @@ namespace Skybrud.Colors {
         /// <param name="m">The magenta of the CMYK color.</param>
         /// <param name="y">The yellow of the CMYK color.</param>
         /// <param name="k">The key of the CMYK color.</param>
-        public static void RgbToCmyk(int red, int green, int blue, out double c, out double m, out double y, out double k) {
+        public static void RgbToCmyk(int red, int green, int blue, out double c, out double m, out double y, out double k)
+        {
             RgbToCmy(red, green, blue, out double cyan, out double magenta, out double yellow);
             CmyToCmyk(cyan, magenta, yellow, out c, out m, out y, out k);
         }
@@ -876,7 +952,8 @@ namespace Skybrud.Colors {
         /// <param name="m">The magenta of the CMYK color.</param>
         /// <param name="y">The yellow of the CMYK color.</param>
         /// <param name="k">The key of the CMYK color.</param>
-        public static void RgbToCmyk(double red, double green, double blue, out double c, out double m, out double y, out double k) {
+        public static void RgbToCmyk(double red, double green, double blue, out double c, out double m, out double y, out double k)
+        {
             RgbToCmy(red, green, blue, out double cyan, out double magenta, out double yellow);
             CmyToCmyk(cyan, magenta, yellow, out c, out m, out y, out k);
         }
@@ -888,7 +965,8 @@ namespace Skybrud.Colors {
         /// <param name="green">The green of the RGB color.</param>
         /// <param name="blue">The blue of the RGB color.</param>
         /// <returns>An instance of <see cref="CmykColor"/> representing the CMYK color.</returns>
-        public static CmykColor RgbToCmyk(double red, double green, double blue) {
+        public static CmykColor RgbToCmyk(double red, double green, double blue)
+        {
             RgbToCmy(red, green, blue, out double cyan, out double magenta, out double yellow);
             CmyToCmyk(cyan, magenta, yellow, out double c, out double m, out double y, out double k);
             return new CmykColor(c, m, y, k);
@@ -902,7 +980,8 @@ namespace Skybrud.Colors {
         /// <param name="m">The magenta of the CMYK color.</param>
         /// <param name="y">The yellow of the CMYK color.</param>
         /// <param name="k">The key of the CMYK color.</param>
-        public static void RgbToCmyk(RgbColor rgb, out double c, out double m, out double y, out double k) {
+        public static void RgbToCmyk(RgbColor rgb, out double c, out double m, out double y, out double k)
+        {
             RgbToCmyk(rgb.Red, rgb.Green, rgb.Blue, out c, out m, out y, out k);
         }
 
@@ -911,7 +990,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="rgb">The RGB color.</param>
         /// <returns>An instance of <see cref="CmykColor"/> representing the CMYK color.</returns>
-        public static CmykColor RgbToCmyk(RgbColor rgb) {
+        public static CmykColor RgbToCmyk(RgbColor rgb)
+        {
             return RgbToCmyk(rgb.Red, rgb.Green, rgb.Blue);
         }
 
@@ -928,7 +1008,8 @@ namespace Skybrud.Colors {
         /// <param name="hue">The amount of hue in the HSL color.</param>
         /// <param name="saturation">The amount of saturation in the HSL color.</param>
         /// <param name="lightness">The amount of lightness in the HSL color.</param>
-        public static void RgbToHsl(byte red, byte green, byte blue, out double hue, out double saturation, out double lightness) {
+        public static void RgbToHsl(byte red, byte green, byte blue, out double hue, out double saturation, out double lightness)
+        {
             int r = red;
             int g = green;
             int b = blue;
@@ -944,7 +1025,8 @@ namespace Skybrud.Colors {
         /// <param name="hue">The amount of hue in the HSL color.</param>
         /// <param name="saturation">The amount of saturation in the HSL color.</param>
         /// <param name="lightness">The amount of lightness in the HSL color.</param>
-        public static void RgbToHsl(int red, int green, int blue, out double hue, out double saturation, out double lightness) {
+        public static void RgbToHsl(int red, int green, int blue, out double hue, out double saturation, out double lightness)
+        {
 
             // Convert to values from 0-1 (linear)
             double r = red / 255d;
@@ -960,21 +1042,30 @@ namespace Skybrud.Colors {
 
             // Calculate the saturation
             saturation = 0;
-            if (Math.Abs(max - min) > Double.Epsilon) {
-                if (lightness < 0.5) {
+            if (Math.Abs(max - min) > Double.Epsilon)
+            {
+                if (lightness < 0.5)
+                {
                     saturation = (max - min) / (max + min);
-                } else {
+                }
+                else
+                {
                     saturation = (max - min) / (2.0d - max - min);
                 }
             }
 
             // Calculate the hue
             hue = 0;
-            if (Math.Abs(r - max) < Double.Epsilon) {
+            if (Math.Abs(r - max) < Double.Epsilon)
+            {
                 hue = (g - b) / (max - min);
-            } else if (Math.Abs(g - max) < Double.Epsilon) {
+            }
+            else if (Math.Abs(g - max) < Double.Epsilon)
+            {
                 hue = 2.0d + (b - r) / (max - min);
-            } else if (Math.Abs(b - max) < Double.Epsilon) {
+            }
+            else if (Math.Abs(b - max) < Double.Epsilon)
+            {
                 hue = 4.0d + (r - g) / (max - min);
             }
 
@@ -998,8 +1089,76 @@ namespace Skybrud.Colors {
         /// <param name="red">The amount of red in the RGB color.</param>
         /// <param name="green">The amount of green in the RGB color.</param>
         /// <param name="blue">The amount of blue in the RGB color.</param>
+        /// <param name="hue">The amount of hue in the HSL color.</param>
+        /// <param name="saturation">The amount of saturation in the HSL color.</param>
+        /// <param name="lightness">The amount of lightness in the HSL color.</param>
+        public static void RgbToHslFloat(byte red, byte green, byte blue, out float hue, out float saturation, out float lightness)
+        {
+
+            // Convert to values from 0-1 (linear)
+            float r = red / 255f;
+            float g = green / 255f;
+            float b = blue / 255f;
+
+            // Get the maximum and minimum values
+            float max = Max(r, g, b);
+            float min = Min(r, g, b);
+
+            // Calculate the lightness
+            lightness = (max + min) / 2f;
+
+            // Calculate the saturation
+            saturation = 0;
+            if (Math.Abs(max - min) > Double.Epsilon)
+            {
+                if (lightness < 0.5)
+                {
+                    saturation = (max - min) / (max + min);
+                }
+                else
+                {
+                    saturation = (max - min) / (2.0f - max - min);
+                }
+            }
+
+            // Calculate the hue
+            hue = 0;
+            if (Math.Abs(r - max) < Double.Epsilon)
+            {
+                hue = (g - b) / (max - min);
+            }
+            else if (Math.Abs(g - max) < Double.Epsilon)
+            {
+                hue = 2.0f + (b - r) / (max - min);
+            }
+            else if (Math.Abs(b - max) < Double.Epsilon)
+            {
+                hue = 4.0f + (r - g) / (max - min);
+            }
+
+            // Convert the hue to degrees
+            hue = hue * 60;
+
+            // Make sure hue is a positive number
+            if (hue < 0.0) hue += 360;
+
+            // Convert the hue back to a decimal
+            hue = hue / 360f;
+
+            // Make sure hue is not NaN
+            if (Single.IsNaN(hue)) hue = 0;
+
+        }
+
+        /// <summary>
+        /// Converts a RGB color to an HSL color.
+        /// </summary>
+        /// <param name="red">The amount of red in the RGB color.</param>
+        /// <param name="green">The amount of green in the RGB color.</param>
+        /// <param name="blue">The amount of blue in the RGB color.</param>
         /// <returns>An instance of <see cref="HslColor"/> representing the </returns>
-        public static HslColor RgbToHsl(int red, int green, int blue) {
+        public static HslColor RgbToHsl(int red, int green, int blue)
+        {
             RgbToHsl(red, green, blue, out double h, out double s, out double l);
             return new HslColor(h, s, l);
         }
@@ -1009,7 +1168,8 @@ namespace Skybrud.Colors {
         /// </summary>
         /// <param name="rgb">The RGB color.</param>
         /// <returns>An instance of <see cref="HslColor"/> representing the </returns>
-        public static HslColor RgbToHsl(RgbColor rgb) {
+        public static HslColor RgbToHsl(RgbColor rgb)
+        {
             RgbToHsl(rgb.Red, rgb.Green, rgb.Blue, out double h, out double s, out double l);
             return new HslColor(h, s, l);
         }
@@ -1018,21 +1178,148 @@ namespace Skybrud.Colors {
 
         #region RGB -> HSV
 
-        public static void RgbToHsv(int red, int green, int blue, out double h, out double s, out double v) {
+        public static void RgbToHsv(int red, int green, int blue, out double h, out double s, out double v)
+        {
             RgbToHsl(red, green, blue, out double hue, out double saturation, out double lightness);
             HslToHsv(hue, saturation, lightness, out h, out s, out v);
         }
 
-        public static HsvColor RgbToHsv(int red, int green, int blue) {
+        public static HsvColor RgbToHsv(int red, int green, int blue)
+        {
             RgbToHsl(red, green, blue, out double hue, out double saturation, out double lightness);
             HslToHsv(hue, saturation, lightness, out double h, out double s, out double v);
             return new HsvColor(h, s, v);
         }
 
-        public static HsvColor RgbToHsv(RgbColor rgb) {
+        public static HsvColor RgbToHsv(RgbColor rgb)
+        {
             RgbToHsl(rgb.Red, rgb.Green, rgb.Blue, out double hue, out double saturation, out double lightness);
             HslToHsv(hue, saturation, lightness, out double h, out double s, out double v);
             return new HsvColor(h, s, v);
+        }
+
+        #endregion
+
+        #region HEX -> RGB
+
+        /// <summary>
+        /// Converts a <strong>HEX</strong> color with the specified <paramref name="hex"/> to the corresponding <strong>RGB</strong> color.
+        /// </summary>
+        /// <param name="hex">The hex code of the color.</param>
+        /// <param name="red">The red of the RGB color.</param>
+        /// <param name="green">The green of the RGB color.</param>
+        /// <param name="blue">The blue of the RGB color.</param>
+        public static void HexToRgb(string hex, out double red, out double green, out double blue)
+        {
+            var rgb = HexToRgb(hex);
+            red = rgb.Red;
+            green = rgb.Green;
+            blue = rgb.Blue;
+        }
+
+        /// <summary>
+        /// Converts a <strong>HEX</strong> color with the specified <paramref name="hex"/> to the corresponding <strong>RGB</strong> color.
+        /// </summary>
+        /// <param name="hex">The hex code of the color.</param>
+        /// <param name="red">The red of the RGB color.</param>
+        /// <param name="green">The green of the RGB color.</param>
+        /// <param name="blue">The blue of the RGB color.</param>
+        public static void HexToRgb(string hex, out int red, out int green, out int blue)
+        {
+            var rgb = HexToRgb(hex);
+            red = rgb.Red;
+            green = rgb.Green;
+            blue = rgb.Blue;
+        }
+
+        /// <summary>
+        /// Converts a <strong>HEX</strong> color with the specified <paramref name="hex"/> to the corresponding <strong>RGB</strong> color.
+        /// </summary>
+        /// <param name="hex">The hex code of the color.</param>
+        /// <returns>An instance of <see cref="RgbColor"/> representing the RGB.</returns>
+        public static RgbColor HexToRgb(string hex)
+        {
+            if (String.IsNullOrWhiteSpace(hex)) throw new ArgumentNullException("hex");
+
+            IColor color;
+            if (TryParse(hex, out color)) return color as RgbColor;
+
+            throw new FormatException("Not a valid Hexadecimal value.");
+        }
+
+        #endregion
+
+        #region Parsing
+        //Moved from ColorHelper
+
+        /// <summary>
+        /// Parses the specified <paramref name="str"/> into an instance of <see cref="IColor"/>.
+        /// </summary>
+        /// <param name="str">The input string to be parsed.</param>
+        /// <returns>An instance of <see cref="IColor"/>.</returns>
+        public static IColor Parse(string str)
+        {
+            if (String.IsNullOrWhiteSpace(str)) throw new ArgumentNullException("str");
+
+            IColor color;
+            if (TryParse(str, out color)) return color;
+
+            throw new FormatException("Input string was not in a correct format.");
+
+        }
+
+        /// <summary>
+        /// Attempts to parse the specified <paramref name="str"/> into an instance of <see cref="IColor"/>.
+        /// </summary>
+        /// <param name="str">The input string to be parsed.</param>
+        /// <param name="color">An instance of <see cref="IColor"/>.</param>
+        /// <returns><c>true</c> if <paramref name="str"/> was converted successfully; otherwise, <c>false</c>.</returns>
+        public static bool TryParse(string str, out IColor color)
+        {
+
+            color = null;
+
+            // Return "false" if the string is empty
+            if (String.IsNullOrWhiteSpace(str)) return false;
+
+            // Strip a leading hashtag and convert to lowercase
+            str = str.TrimStart('#').ToLower();
+
+            // Time for some regex :D
+            Match m1 = Regex.Match(str, "^([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$");
+            Match m2 = Regex.Match(str, "^([0-9a-f]{1})([0-9a-f]{1})([0-9a-f]{1})$");
+
+            Match m3 = Regex.Match(str, "^hsl\\(([0-9]+), ([0-9]+)%, ([0-9]+)%\\)$");
+
+            if (m1.Success)
+            {
+                Byte.TryParse(m1.Groups[1].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte r);
+                Byte.TryParse(m1.Groups[2].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte g);
+                Byte.TryParse(m1.Groups[3].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte b);
+                color = new RgbColor(r, g, b);
+                return true;
+            }
+
+            if (m2.Success)
+            {
+                Byte.TryParse(m2.Groups[1].Value + m2.Groups[1].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte r);
+                Byte.TryParse(m2.Groups[2].Value + m2.Groups[2].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte g);
+                Byte.TryParse(m2.Groups[3].Value + m2.Groups[3].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte b);
+                color = new RgbColor(r, g, b);
+                return true;
+            }
+
+            if (m3.Success)
+            {
+                float h = Int32.Parse(m3.Groups[1].Value) / 360f;
+                float s = Int32.Parse(m3.Groups[2].Value) / 100f;
+                float l = Int32.Parse(m3.Groups[3].Value) / 100f;
+                color = new HslColor(h, s, l);
+                return true;
+            }
+
+            return false;
+
         }
 
         #endregion

--- a/src/Skybrud.Colors/Properties/AssemblyInfo.json
+++ b/src/Skybrud.Colors/Properties/AssemblyInfo.json
@@ -6,5 +6,5 @@
   "copyright": "Copyright © 2018",
   "version": "1.0.2.0",
   "informationalVersion": "1.0.2",
-  "fileVersion": "0.0.855.1"
+  "fileVersion": "0.0.1901.7"
 }

--- a/src/Skybrud.Colors/Properties/AssemblyInfo.json
+++ b/src/Skybrud.Colors/Properties/AssemblyInfo.json
@@ -6,5 +6,5 @@
   "copyright": "Copyright © 2018",
   "version": "1.0.2.0",
   "informationalVersion": "1.0.2",
-  "fileVersion": "0.0.1901.7"
+  "fileVersion": "0.0.1902.5"
 }

--- a/src/Skybrud.Colors/Properties/AssemblyInfoGenerated.cs
+++ b/src/Skybrud.Colors/Properties/AssemblyInfoGenerated.cs
@@ -1,4 +1,4 @@
 using System.Reflection;
 
-[assembly: AssemblyFileVersion("0.0.1901.7")]
+[assembly: AssemblyFileVersion("0.0.1902.5")]
 

--- a/src/Skybrud.Colors/Properties/AssemblyInfoGenerated.cs
+++ b/src/Skybrud.Colors/Properties/AssemblyInfoGenerated.cs
@@ -1,4 +1,4 @@
 using System.Reflection;
 
-[assembly: AssemblyFileVersion("0.0.855.1")]
+[assembly: AssemblyFileVersion("0.0.1901.7")]
 

--- a/src/UnitTestProject1/RgbColorTests.cs
+++ b/src/UnitTestProject1/RgbColorTests.cs
@@ -28,7 +28,7 @@ namespace UnitTestProject1 {
             foreach (HtmlColorSample sample in HtmlColorSamples.All)
             {
                 string hex = sample.Hex;
-                RgbColor colorTest = ColorHelpers.HexadecimalToRgb(hex);
+                RgbColor colorTest = ColorUtils.HexToRgb(hex);
                 Assert.AreEqual(sample.Hex, colorTest.ToHex(), sample.Name);
                 Assert.AreEqual(sample.Rgb.Red, colorTest.Red, sample.Name);
                 Assert.AreEqual(sample.Rgb.Green, colorTest.Green, sample.Name);

--- a/src/UnitTestProject1/RgbColorTests.cs
+++ b/src/UnitTestProject1/RgbColorTests.cs
@@ -23,6 +23,20 @@ namespace UnitTestProject1 {
         }
 
         [TestMethod]
+        public void FromHex()
+        {
+            foreach (HtmlColorSample sample in HtmlColorSamples.All)
+            {
+                string hex = sample.Hex;
+                RgbColor colorTest = ColorHelpers.HexadecimalToRgb(hex);
+                Assert.AreEqual(sample.Hex, colorTest.ToHex(), sample.Name);
+                Assert.AreEqual(sample.Rgb.Red, colorTest.Red, sample.Name);
+                Assert.AreEqual(sample.Rgb.Green, colorTest.Green, sample.Name);
+                Assert.AreEqual(sample.Rgb.Blue, colorTest.Blue, sample.Name);
+            }
+        }
+
+        [TestMethod]
         public void ToHsl() {
 
             foreach (HtmlColorSample sample in HtmlColorSamples.All) {


### PR DESCRIPTION
- Consolidated ColorHelpers into ColorUtils
- Obsoleted ColorHelpers functions
- Added ColorUtils.HexToRgb() (Using .Parse() function)*

*Feel free to rewrite this if you want to use something other than your RegEx parse function. 

Also, I modeled the HexToRgb() functions after the others (ex: HslToRgb()), but I'm not sure whether the options are all useful or not.